### PR TITLE
chore: remove unused var

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -2,10 +2,6 @@ variable "kvm_subnet" {
   type    = string
   default = "172.16.0.0/24"
 }
-variable "kvm_subnet_prefix" {
-  type    = string
-  default = "172.16.0"
-}
 
 variable "network_name" {
   description = "A name to provide for the k8s cluster network"


### PR DESCRIPTION
`kvm_subnet_prefix` does not look to be used by this module, so removing it